### PR TITLE
chore: update npm-publish workflow permissions 

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@
 
 name: Node.js Package
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 on:
   release:
     types: [created]
@@ -30,5 +34,3 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Update npm-publish workflow permissions 
Remove NODE_AUTH_TOKEN environment variable