### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,5 +1,8 @@
 name: Run npm test & npm lint on Pull Requests
 
+permissions:
+  contents: read
+
 on:
   - pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/Deltares/fews-web-oc-utils/security/code-scanning/2](https://github.com/Deltares/fews-web-oc-utils/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions:` block that grants only the minimal privileges required. For a workflow that only needs to read the repository contents to run tests and lint on pull requests, `contents: read` is sufficient. Because no job needs to write to the repo, issues, or pull requests, we should not grant any write scopes.

The best way to fix this without changing existing functionality is to add a top-level `permissions:` block (so it applies to all jobs) directly under the workflow name and before the `on:` block in `.github/workflows/npm-test.yml`. This will constrain the GITHUB_TOKEN for all jobs in this workflow to read-only repository contents, which is all that the current steps (`actions/checkout`, `actions/setup-node`, `npm ci`, tests, lint) require.

Concretely:
- Edit `.github/workflows/npm-test.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: Run npm test & npm lint on Pull Requests`) and before the existing `on:` block.
- No additional imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
